### PR TITLE
回復アイテムの修正

### DIFF
--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -15,6 +15,10 @@ public class UseEquippedItem : MonoBehaviour
         {
             UseBombItem();
         }
+    }
+
+    public void AutoItem()
+    {
         if(this.gameObject.name == "RecoverItemEquipped(Clone)")
         {
             UseRecoverItem();

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -48,6 +48,7 @@ public class UseEquippedItem : MonoBehaviour
         GameObject myPlayer = GameObject.FindGameObjectWithTag("Player");
         myPlayer.GetComponent<MachineBehavior>().HP += 10f;
 
+        // TODO: 一度Destroyするとめっちゃエラー出るから修正する
         Destroy(GameObject.Find("RecoverItemEquipped(Clone)"));
     }
 }

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -45,5 +45,9 @@ public class UseEquippedItem : MonoBehaviour
     void UseRecoverItem()
     {
         Debug.Log("*** RecoverItemを使用 ***");
+        GameObject myPlayer = GameObject.FindGameObjectWithTag("Player");
+        myPlayer.GetComponent<MachineBehavior>().HP += 10f;
+
+        Destroy(GameObject.Find("RecoverItemEquipped(Clone)"));
     }
 }

--- a/Assets/Scripts/MachineBehavior.cs
+++ b/Assets/Scripts/MachineBehavior.cs
@@ -93,16 +93,20 @@ public class MachineBehavior : MonoBehaviour
              MachineDestroyedEvent();
         }
 
+        foreach (Transform n in this.gameObject.transform)
+        {
+            if (n.name.Contains("Equipped"))
+            {
+                this.EquippedItem = n.gameObject;
+            }
+        }
+        try
+        {
+            this.EquippedItem.GetComponent<UseEquippedItem>().AutoItem();
+        }
+        catch(UnassignedReferenceException) {}
         if(Input.GetKeyUp(KeyCode.U))
         {
-            foreach (Transform n in this.gameObject.transform)
-            {
-               if (n.name.Contains("Equipped"))
-               {
-                   this.EquippedItem = n.gameObject;
-               }
-            } 
-
             try
             {
                 this.EquippedItem.GetComponent<UseEquippedItem>().Use();
@@ -111,8 +115,6 @@ public class MachineBehavior : MonoBehaviour
             {
                 Debug.Log("*** アイテムが装備されていません");
             }
-
-
         }
     }
 


### PR DESCRIPTION
issue #54 

やったこと
・回復アイテムに触れた瞬間に使用する
・実際にHPが回復する
・回復したらすぐEquipped状態を解消

残り作業
・一度回復アイテムをとった後めっちゃエラーが出るので（ゲーム進行には影響なさそう），修正する

エラー文
MissingReferenceException: The object of type 'GameObject' has been destroyed but you are still trying to access it.
Your script should either check if it is null or you should not destroy the object.