### PR TITLE
update: BombItemに当たり判定とダメージを追加

### DIFF
--- a/Assets/Prefabs/Bomb.prefab
+++ b/Assets/Prefabs/Bomb.prefab
@@ -13,6 +13,7 @@ GameObject:
   - component: {fileID: 8222688684855513020}
   - component: {fileID: 1399212458213308426}
   - component: {fileID: 8198151801724867066}
+  - component: {fileID: -3966737083398638777}
   m_Layer: 0
   m_Name: Bomb
   m_TagString: Untagged
@@ -91,7 +92,7 @@ SphereCollider:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4658210592918138956}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 0.5
@@ -112,3 +113,15 @@ Rigidbody:
   m_Interpolate: 0
   m_Constraints: 0
   m_CollisionDetection: 0
+--- !u!114 &-3966737083398638777
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4658210592918138956}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 69d81fca3373743ab9cf3f84a7e3db03, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Scripts/ItemScripts/BombManager.cs
+++ b/Assets/Scripts/ItemScripts/BombManager.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BombManager : MonoBehaviour
+{
+    Rigidbody rb;
+    Vector3 force_vector;
+    // Start is called before the first frame update
+    void Start()
+    {
+        rb = GetComponent<Rigidbody>();
+        force_vector = - transform.forward * 10f + transform.up * 2f;
+        rb.AddForce(force_vector, ForceMode.Impulse);
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // TODO: 自分にもヒットするので直す
+        if (other.CompareTag("Player"))
+        {
+            other.GetComponent<MachineBehavior>().HP -= 10f;
+        }
+
+    }
+}

--- a/Assets/Scripts/ItemScripts/BombManager.cs.meta
+++ b/Assets/Scripts/ItemScripts/BombManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 69d81fca3373743ab9cf3f84a7e3db03
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
実装内容：BombItemのアップデート
・当たったらダメージ
・一定時間経つと消える

実装の概要：BulletItemに倣って実装
・BombManager.csの追加（forceの値以外はBulletManager.csと一緒）
・BombItemに当たり判定を追加 & BombManager.csのアタッチ

気になること
・自分に当たってHPが減る（CannonのBulletと同じ）
・一定時間経つ or 接触 で爆発し、その周囲にいるプレイヤーにダメージが加わる　 の方が自然かも