### PR TITLE
feat: Bombに爆発とダメージを追加

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -49,13 +49,12 @@ MonoBehaviour:
     m_Address: Assets/Prefabs/Bomb.prefab
     m_ReadOnly: 0
     m_SerializedLabels: []
-  - m_GUID: fafeb973cad62304ba2abdc5dfafbf8f
-    m_Address: Assets/JMO Assets/WarFX/_Effects (Mobile)/Explosions/WFXMR_ExplosiveSmokeGround
-      Big.prefab
-    m_ReadOnly: 0
-    m_SerializedLabels: []
   - m_GUID: ded75c4d5ad70fd4391d248d78498cc6
     m_Address: Assets/Prefabs/ExplosionFieldLarge.prefab
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+  - m_GUID: 1c8065099ab3145a78837fd7d0123526
+    m_Address: Assets/Prefabs/ExplosionFieldSmall.prefab
     m_ReadOnly: 0
     m_SerializedLabels: []
   m_ReadOnly: 0

--- a/Assets/Prefabs/ExplosionFieldSmall.prefab
+++ b/Assets/Prefabs/ExplosionFieldSmall.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &4658210592918138956
+--- !u!1 &6718208064908783421
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,48 +8,47 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 2250473562239341600}
-  - component: {fileID: 8011453857373397487}
-  - component: {fileID: 8222688684855513020}
-  - component: {fileID: 1399212458213308426}
-  - component: {fileID: 8198151801724867066}
-  - component: {fileID: 4470980862831144509}
+  - component: {fileID: 1406490076800928942}
+  - component: {fileID: 1785837676040339036}
+  - component: {fileID: -2856210581917594458}
+  - component: {fileID: 6977227998710200305}
+  - component: {fileID: 5356030596893625352}
   m_Layer: 0
-  m_Name: Bomb
+  m_Name: ExplosionFieldSmall
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2250473562239341600
+--- !u!4 &1406490076800928942
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4658210592918138956}
+  m_GameObject: {fileID: 6718208064908783421}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.4661889, y: 1.954268, z: 1.5706139}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_LocalPosition: {x: 5, y: 0, z: 9}
+  m_LocalScale: {x: 0.4, y: 0.4, z: 0.4}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &8011453857373397487
+--- !u!33 &1785837676040339036
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4658210592918138956}
+  m_GameObject: {fileID: 6718208064908783421}
   m_Mesh: {fileID: 10207, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8222688684855513020
+--- !u!23 &-2856210581917594458
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4658210592918138956}
+  m_GameObject: {fileID: 6718208064908783421}
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -84,46 +83,31 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &1399212458213308426
+--- !u!135 &6977227998710200305
 SphereCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4658210592918138956}
+  m_GameObject: {fileID: 6718208064908783421}
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
   m_Radius: 0.5
   m_Center: {x: 0, y: 0, z: 0}
---- !u!54 &8198151801724867066
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4658210592918138956}
-  serializedVersion: 2
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_UseGravity: 1
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 0
-  m_CollisionDetection: 0
---- !u!114 &4470980862831144509
+--- !u!114 &5356030596893625352
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4658210592918138956}
+  m_GameObject: {fileID: 6718208064908783421}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9c28b73c70af0ce4390291032ace77c5, type: 3}
+  m_Script: {fileID: 11500000, guid: 2f5b2d6be4fd05b4a9fe8cd9fe5b3f8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  machine: {fileID: 2805079637915772865, guid: a713093a5ec9f98db8f1c43f95a57d48, type: 3}
-  survivalTime: 0.5
+  ExplosionScale: 10
+  LifeSpan: 50
+  Damage: 10

--- a/Assets/Prefabs/ExplosionFieldSmall.prefab.meta
+++ b/Assets/Prefabs/ExplosionFieldSmall.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1c8065099ab3145a78837fd7d0123526
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/ItemScripts/BombManager.cs
+++ b/Assets/Scripts/ItemScripts/BombManager.cs
@@ -1,32 +1,36 @@
 using System.Collections;
 using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
+using UnityEngine.AddressableAssets;
 
 public class BombManager : MonoBehaviour
 {
     Rigidbody rb;
     Vector3 force_vector;
+    public float survivalTime = 0.5f;
+
     // Start is called before the first frame update
     void Start()
     {
         rb = GetComponent<Rigidbody>();
-        
-        float force_rand = Random.Range(10f, 50f);
-        force_vector = transform.forward * force_rand * -1f;
-        
-        float side_rand = Random.Range(-45f, 45f);
-        float up_rand = Random.Range(0f, 45f);
-        force_vector = Quaternion.Euler(up_rand, side_rand, 0) * force_vector;
-        
+        float force_rand = Random.Range(10f, 20f);
+        float side_rand = Random.Range(-5f, 5f);
+        force_vector = side_rand * transform.right - force_rand * transform.forward;
         rb.AddForce(force_vector, ForceMode.Impulse);
     }
 
     // Update is called once per frame
     void Update()
     {
-    }
-
-    private void OnTriggerEnter(Collider other)
-    {
+        survivalTime -= Time.deltaTime;
+        if (survivalTime <= 0)
+        {
+            Addressables.InstantiateAsync(
+                "Assets/Prefabs/ExplosionFieldSmall.prefab",
+                this.transform.position, this.transform.rotation
+            );
+            Destroy(this.gameObject);
+        }
     }
 }

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -31,15 +31,20 @@ public class UseEquippedItem : MonoBehaviour
     void UseBombItem()
     {
         Debug.Log("*** BombItemを使用 ***");
-        for (int n = 0; n < 12; n++)
-        {
-            Addressables.InstantiateAsync("Assets/Prefabs/Bomb.prefab", 
-                this.transform.position,
-                this.transform.rotation);
-        }
+        float start_time = Time.time;
+        StartCoroutine("ThroughBomb");
     }
     void UseRecoverItem()
     {
         Debug.Log("*** RecoverItemを使用 ***");
+    }
+    IEnumerator ThroughBomb()
+    {
+        for (int n = 0; n < 5; n++) {
+            Addressables.InstantiateAsync("Assets/Prefabs/Bomb.prefab", 
+                this.transform.position, this.transform.rotation
+            );
+            yield return new WaitForSeconds(0.1f);
+        }
     }
 }


### PR DESCRIPTION
実装内容：BombItemのアップデート
・一定時間経つと爆発し、爆風に接触するとダメージを受けるようにした
・球の数を5個に減らし、勢いを弱めた

実装の概要：BulletItemに倣って実装
1. BombManager.csを追加し、BombItemにアタッチ（BulletManager.csに倣う）
・マシン後方に飛ぶ球を作成
・球は一定時間経つとExplosionFieldSmall（接触するとダメージ）を出して消える

2. ExplosionFieldSmallプレハブの作成（ExplosionFieldLargeに倣う）
・Explosion.csをアタッチ

3. UseEquippedItem.csのUseBombItem()を変更
・球の数を5個に減らした
・球の干渉対策のため、同時でなく0.1秒間隔で球を放出