### PR TITLE
回転炎の見た目とダメージ判定実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ Thumbs.db
 #purchessed assets
 Assets/JMO\ Assets/
 Assets/Shared/
+Assets/EffectExamples/

--- a/Assets/EffectExamples.meta
+++ b/Assets/EffectExamples.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 6c0b056137d972f46a0312ba21b6263f
+folderAsset: yes
+timeCreated: 1473947300
+licenseType: Store
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Materials/RedTransparent.mat
+++ b/Assets/Materials/RedTransparent.mat
@@ -74,6 +74,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 0
     m_Colors:
-    - _Color: {r: 1, g: 0.078431375, b: 0.09019608, a: 0}
+    - _Color: {r: 0, g: 1, b: 0.26565313, a: 0}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Scenes/CityTrial.unity
+++ b/Assets/Scenes/CityTrial.unity
@@ -3521,7 +3521,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192903, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
       propertyPath: m_Enabled
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192903, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
       propertyPath: m_Materials.Array.data[0]

--- a/Assets/Scenes/CityTrial.unity
+++ b/Assets/Scenes/CityTrial.unity
@@ -1543,6 +1543,87 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1050709465
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 105205852}
+    m_Modifications:
+    - target: {fileID: 1634767862067424, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_Name
+      value: FlameThrower
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 5.775937
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.50200003
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 198637950067575458, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: simulationSpeed
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 199192134335169774, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 199982541912562440, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
+      propertyPath: m_Materials.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
 --- !u!1 &1077903438
 GameObject:
   m_ObjectHideFlags: 0
@@ -3391,8 +3472,16 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 11.798
+      objectReference: {fileID: 0}
+    - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.8291687
+      objectReference: {fileID: 0}
+    - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 5.02
+      value: 5.9191
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
       propertyPath: m_LocalPosition.y
@@ -3400,7 +3489,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -0.02
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
       propertyPath: m_LocalRotation.w
@@ -3429,6 +3518,10 @@ PrefabInstance:
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1388745263167192903, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192903, guid: 47dcc90c35ca3a64bb67d28dd977038c, type: 3}
       propertyPath: m_Materials.Array.data[0]


### PR DESCRIPTION
# 内容
- rotatingWallでダメージ判定を実装
- FlameThrowerで炎の見た目を実装
- ヒエラルキー：CityTrial/Field1/CenterPole/RotatingWall/FlameThrower
- 炎のAssetはAsset共有のgoogle dcumentを参照してください．

# 今後の作業
- CenterPoleがただの円柱でチープなのでいい感じの見た目にしたい