### PR TITLE
回復アイテムの仕様変更＋α

### DIFF
--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -41,6 +41,9 @@ public class UseEquippedItem : MonoBehaviour
     void UseRecoverItem()
     {
         Debug.Log("*** RecoverItemを使用 ***");
+        GameObject machineObj = this.gameObject.transform.parent.gameObject;
+        machineObj.GetComponent<MachineBehavior>().HP += 15f;
+        Destroy(this.gameObject);
     }
     IEnumerator ThroughBomb()
     {

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -23,16 +23,20 @@ public class UseEquippedItem : MonoBehaviour
 
     void UseCannonItem()
     {
-        Debug.Log("***CannonItemを使用***");
-        Addressables.InstantiateAsync("Assets/Prefabs/Bullet.prefab", 
-            this.transform.position,
-            this.transform.rotation);
+        if(Input.GetKeyUp(KeyCode.U)) {
+            Debug.Log("***CannonItemを使用***");
+             Addressables.InstantiateAsync("Assets/Prefabs/Bullet.prefab", 
+                this.transform.position,
+                this.transform.rotation);
+        }
     }
     void UseBombItem()
     {
-        Debug.Log("*** BombItemを使用 ***");
-        float start_time = Time.time;
-        StartCoroutine("ThroughBomb");
+        if(Input.GetKeyUp(KeyCode.U)) {
+            Debug.Log("*** BombItemを使用 ***");
+            float start_time = Time.time;
+            StartCoroutine("ThroughBomb");
+        }
     }
     void UseRecoverItem()
     {

--- a/Assets/Scripts/MachineBehavior.cs
+++ b/Assets/Scripts/MachineBehavior.cs
@@ -112,26 +112,25 @@ public class MachineBehavior : MonoBehaviour
              MachineDestroyedEvent();
         }
 
-        if(Input.GetKeyUp(KeyCode.U))
+        foreach (Transform n in this.gameObject.transform)
         {
-            foreach (Transform n in this.gameObject.transform)
+            if (n.name.Contains("Equipped"))
             {
-               if (n.name.Contains("Equipped"))
-               {
-                   this.EquippedItem = n.gameObject;
-               }
-            } 
-
-            try
-            {
-                this.EquippedItem.GetComponent<UseEquippedItem>().Use();
+                this.EquippedItem = n.gameObject;
             }
-            catch(UnassignedReferenceException)
-            {
-                Debug.Log("*** アイテムが装備されていません");
-            }
+        } 
 
-
+        try
+        {
+            this.EquippedItem.GetComponent<UseEquippedItem>().Use();
+        }
+        catch(UnassignedReferenceException)
+        {
+            Debug.Log("*** アイテムが装備されていません");
+        }
+        catch(MissingReferenceException)
+        {
+            Debug.Log("*** アイテムがすでに削除されています");
         }
     }
 


### PR DESCRIPTION
# 概要
- 回復アイテムに触れたら，MachineBehaviorで定義しているHPを15増加させる
- 回復処理が終わったら，RecovoerItemEquippedを削除

# 内容
- いじったファイル：MachineBehavior.cs, UseEquippedItem.cs
- 回復アイテムの処理はUキーを押さなくても実行するために，Uキー入力処理をMachineBehaviorからUseEquippedItemへと移動させた
- その関係で，MachineBehavior.cs中のthis.EquippedItem.GetComponent<UseEquippedItem>().Use()　がエラー出るようになってしまったので，catch(MissingReferenceException)を追加
- UseRecoverItem中で，回復処理とアイテムの削除処理を追加

# 今後の作業
回復アイテムだけに限らないが，今後アイテムの使用回数の設定などをするにあたって，アイテムスクリプトを各アイテムごとにクラス化する必要があると思います．