### PR TITLE
大砲とボムに使用回数制限を設定

### DIFF
--- a/Assets/Main Camera Profile.asset.meta
+++ b/Assets/Main Camera Profile.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a2c5621595413ca4a81d437f1d534aff
-NativeFormatImporter:
-  externalObjects: {}
-  mainObjectFileID: 11400000
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Readme.asset.meta
+++ b/Assets/Readme.asset.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 83c2ed844a8c74b779a4c823d16594b1
-timeCreated: 1484217493
-licenseType: Store
-NativeFormatImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scenes/Main.unity.meta
+++ b/Assets/Scenes/Main.unity.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 163adec682b5ccd4c8dbb7766c20f3fb
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -41,6 +41,9 @@ public class UseEquippedItem : MonoBehaviour
     void UseRecoverItem()
     {
         Debug.Log("*** RecoverItemを使用 ***");
+        GameObject machineObj = this.gameObject.transform.parent.gameObject;
+        machineObj.GetComponent<MachineBehavior>().HP += 15f;
+        Destroy(this.gameObject);
     }
     IEnumerator ThroughBomb()
     {

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -9,6 +9,12 @@ public class UseEquippedItem : MonoBehaviour
     public int maxBombUse = 5;
     public int currentUse = 0;
 
+    void DestroyItem()
+    {
+        Debug.Log("使用回数に達しました");
+        Destroy(this.gameObject);
+    }
+
     public void Use()
     {
         if(this.gameObject.name == "CannonItemEquipped(Clone)")
@@ -27,35 +33,33 @@ public class UseEquippedItem : MonoBehaviour
 
     void UseCannonItem()
     {
-        if(Input.GetKeyUp(KeyCode.U)) {
-            Debug.Log("***CannonItemを使用***");
-             Addressables.InstantiateAsync("Assets/Prefabs/Bullet.prefab", 
-                this.transform.position,
-                this.transform.rotation);
+        if(currentUse < maxCannonUse) {
+            if(Input.GetKeyUp(KeyCode.U)) {
+                Debug.Log("***CannonItemを使用***");
+                Addressables.InstantiateAsync("Assets/Prefabs/Bullet.prefab", 
+                    this.transform.position,
+                    this.transform.rotation);
 
-            currentUse += 1;
-            Debug.Log(currentUse);
-        }
-
-        if(currentUse >= maxCannonUse) {
-            Debug.Log("使用回数に達しました");
-            Destroy(this.gameObject);
+                currentUse += 1;
+                Debug.Log(currentUse);
+            }
+        } else {
+            Invoke(nameof(DestroyItem), 1.0f);
         }
     }
     void UseBombItem()
     {
-        if(Input.GetKeyUp(KeyCode.U)) {
-            Debug.Log("*** BombItemを使用 ***");
-            float start_time = Time.time;
-            StartCoroutine("ThroughBomb");
+        if(currentUse < maxBombUse) {
+            if(Input.GetKeyUp(KeyCode.U)) {
+                Debug.Log("*** BombItemを使用 ***");
+                float start_time = Time.time;
+                StartCoroutine("ThroughBomb");
 
-            currentUse += 1;
-            Debug.Log(currentUse);
-        }
-
-        if(currentUse >= maxBombUse) {
-            Debug.Log("使用回数に達しました");
-            Destroy(this.gameObject);
+                currentUse += 1;
+                Debug.Log(currentUse);
+            }
+        } else {
+            Invoke(nameof(DestroyItem), 1.0f);
         }
     }
     void UseRecoverItem()
@@ -64,9 +68,6 @@ public class UseEquippedItem : MonoBehaviour
         GameObject machineObj = this.gameObject.transform.parent.gameObject;
         machineObj.GetComponent<MachineBehavior>().HP += 15f;
         Destroy(this.gameObject);
-
-        currentUse += 1;
-        Debug.Log(currentUse);
     }
     IEnumerator ThroughBomb()
     {

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -5,6 +5,10 @@ using UnityEngine.AddressableAssets;
 
 public class UseEquippedItem : MonoBehaviour
 {
+    public int maxBulletUse = 5;
+    public int maxBombUse = 5;
+    public int currentUse = 0;
+
     public void Use()
     {
         if(this.gameObject.name == "CannonItemEquipped(Clone)")
@@ -28,6 +32,9 @@ public class UseEquippedItem : MonoBehaviour
              Addressables.InstantiateAsync("Assets/Prefabs/Bullet.prefab", 
                 this.transform.position,
                 this.transform.rotation);
+
+            currentUse += 1;
+            Debug.Log(currentUse);
         }
     }
     void UseBombItem()
@@ -36,6 +43,9 @@ public class UseEquippedItem : MonoBehaviour
             Debug.Log("*** BombItemを使用 ***");
             float start_time = Time.time;
             StartCoroutine("ThroughBomb");
+
+            currentUse += 1;
+            Debug.Log(currentUse);
         }
     }
     void UseRecoverItem()
@@ -44,6 +54,9 @@ public class UseEquippedItem : MonoBehaviour
         GameObject machineObj = this.gameObject.transform.parent.gameObject;
         machineObj.GetComponent<MachineBehavior>().HP += 15f;
         Destroy(this.gameObject);
+
+        currentUse += 1;
+        Debug.Log(currentUse);
     }
     IEnumerator ThroughBomb()
     {

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -23,16 +23,20 @@ public class UseEquippedItem : MonoBehaviour
 
     void UseCannonItem()
     {
-        Debug.Log("***CannonItemを使用***");
-        Addressables.InstantiateAsync("Assets/Prefabs/Bullet.prefab", 
-            this.transform.position,
-            this.transform.rotation);
+        if(Input.GetKeyUp(KeyCode.U)) {
+            Debug.Log("***CannonItemを使用***");
+             Addressables.InstantiateAsync("Assets/Prefabs/Bullet.prefab", 
+                this.transform.position,
+                this.transform.rotation);
+        }
     }
     void UseBombItem()
     {
-        Debug.Log("*** BombItemを使用 ***");
-        float start_time = Time.time;
-        StartCoroutine("ThroughBomb");
+        if(Input.GetKeyUp(KeyCode.U)) {
+            Debug.Log("*** BombItemを使用 ***");
+            float start_time = Time.time;
+            StartCoroutine("ThroughBomb");
+        }
     }
     void UseRecoverItem()
     {

--- a/Assets/Scripts/ItemScripts/UseEquippedItem.cs
+++ b/Assets/Scripts/ItemScripts/UseEquippedItem.cs
@@ -5,7 +5,7 @@ using UnityEngine.AddressableAssets;
 
 public class UseEquippedItem : MonoBehaviour
 {
-    public int maxBulletUse = 5;
+    public int maxCannonUse = 5;
     public int maxBombUse = 5;
     public int currentUse = 0;
 
@@ -36,6 +36,11 @@ public class UseEquippedItem : MonoBehaviour
             currentUse += 1;
             Debug.Log(currentUse);
         }
+
+        if(currentUse >= maxCannonUse) {
+            Debug.Log("使用回数に達しました");
+            Destroy(this.gameObject);
+        }
     }
     void UseBombItem()
     {
@@ -46,6 +51,11 @@ public class UseEquippedItem : MonoBehaviour
 
             currentUse += 1;
             Debug.Log(currentUse);
+        }
+
+        if(currentUse >= maxBombUse) {
+            Debug.Log("使用回数に達しました");
+            Destroy(this.gameObject);
         }
     }
     void UseRecoverItem()

--- a/Assets/Scripts/MachineBehavior.cs
+++ b/Assets/Scripts/MachineBehavior.cs
@@ -112,26 +112,25 @@ public class MachineBehavior : MonoBehaviour
              MachineDestroyedEvent();
         }
 
-        if(Input.GetKeyUp(KeyCode.U))
+        foreach (Transform n in this.gameObject.transform)
         {
-            foreach (Transform n in this.gameObject.transform)
+            if (n.name.Contains("Equipped"))
             {
-               if (n.name.Contains("Equipped"))
-               {
-                   this.EquippedItem = n.gameObject;
-               }
-            } 
-
-            try
-            {
-                this.EquippedItem.GetComponent<UseEquippedItem>().Use();
+                this.EquippedItem = n.gameObject;
             }
-            catch(UnassignedReferenceException)
-            {
-                Debug.Log("*** アイテムが装備されていません");
-            }
+        } 
 
-
+        try
+        {
+            this.EquippedItem.GetComponent<UseEquippedItem>().Use();
+        }
+        catch(UnassignedReferenceException)
+        {
+            Debug.Log("*** アイテムが装備されていません");
+        }
+        catch(MissingReferenceException)
+        {
+            Debug.Log("*** アイテムがすでに削除されています");
         }
     }
 


### PR DESCRIPTION
# 概要
- 大砲とボムを一定回数使用したらそのアイテムが削除されるようにした
- #96 からブランチを切って作成したので，先にそちらのレビューをお願いします．

# 内容
- 現在のアイテム使用回数としてcurrentUseを定義
- 各アイテムの在台使用回数としてmaxCannonUse, maxBombUseを定義
- UseCannonItem, UseBoMombItemの中でcurrentUseをインクリメント
- UseCannonItem, UseBoMombItemの中でcurrentUseとmax***Useを比較して使用制限に達していたらDestroy(this.gameObject)を実行

# 今後の作業
- 残り使用回数をUIに表示したい
![アイテム残回数イメージ](https://user-images.githubusercontent.com/82761537/152734867-5aa08164-9e39-4081-b7bf-199053058cef.jpg)

- 最後まだアイテムを使い切ってない時に回復アイテムをとると，使っていたアイテムが消えてしまうのは違和感があるかも？