### PR TITLE
システム関連のSEを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ Assets/Scenes/Profiles/
 Assets/TextMesh Pro/
 Assets/TutorialInfo/
 Assets/Photon/
+
+# audio files
+Assets/Audio/

--- a/Assets/Audio.meta
+++ b/Assets/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0f8373175b0c4b6ebb6e6d9e7f42fc9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Machine1.prefab
+++ b/Assets/Resources/Machine1.prefab
@@ -223,7 +223,6 @@ MonoBehaviour:
   chargeLv: 0
   maxChargeLv: 100
   dash: 5
-  charge: 0
 --- !u!114 &5956257852727736914
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/MachineSelectScene.unity
+++ b/Assets/Scenes/MachineSelectScene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028331, g: 0.2257133, b: 0.3069217, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028305, g: 0.22571313, b: 0.3069213, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -136,6 +136,7 @@ GameObject:
   - component: {fileID: 129545521}
   - component: {fileID: 129545520}
   - component: {fileID: 129545523}
+  - component: {fileID: 129545524}
   m_Layer: 5
   m_Name: Button_BackToTitle
   m_TagString: Untagged
@@ -269,6 +270,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e17abd65dd7c75a429544dd8e66b8948, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  SE_cancel: {fileID: 8300000, guid: 6f0922591bbd24209b34ef9e87ca811e, type: 3}
+--- !u!82 &129545524
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 129545518}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1001 &173946323
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -445,6 +543,7 @@ GameObject:
   - component: {fileID: 364822467}
   - component: {fileID: 364822466}
   - component: {fileID: 364822465}
+  - component: {fileID: 364822469}
   m_Layer: 5
   m_Name: Button_MachineC
   m_TagString: Untagged
@@ -486,6 +585,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   id: 2
+  SE_button: {fileID: 8300000, guid: 42d1b1a6bd4a94f12a1e2f20d1a78a39, type: 3}
 --- !u!114 &364822466
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -580,6 +680,102 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 364822463}
   m_CullTransparentMesh: 1
+--- !u!82 &364822469
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 364822463}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &366001141
 GameObject:
   m_ObjectHideFlags: 0
@@ -1340,6 +1536,7 @@ GameObject:
   - component: {fileID: 1358983678}
   - component: {fileID: 1358983677}
   - component: {fileID: 1358983676}
+  - component: {fileID: 1358983680}
   m_Layer: 5
   m_Name: Button_MachineA
   m_TagString: Untagged
@@ -1381,6 +1578,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   id: 0
+  SE_button: {fileID: 8300000, guid: 42d1b1a6bd4a94f12a1e2f20d1a78a39, type: 3}
 --- !u!114 &1358983677
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1475,6 +1673,102 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1358983674}
   m_CullTransparentMesh: 1
+--- !u!82 &1358983680
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1358983674}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &1401536417
 GameObject:
   m_ObjectHideFlags: 0
@@ -1567,6 +1861,7 @@ GameObject:
   - component: {fileID: 1417822603}
   - component: {fileID: 1417822602}
   - component: {fileID: 1417822601}
+  - component: {fileID: 1417822605}
   m_Layer: 5
   m_Name: Button_StartGame
   m_TagString: Untagged
@@ -1606,6 +1901,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ac82d8642579b364b9d3073734fb2d08, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  SE_select: {fileID: 8300000, guid: 9908835e1668942cebe8f5fe51df81ed, type: 3}
 --- !u!114 &1417822602
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1712,6 +2008,102 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1417822599}
   m_CullTransparentMesh: 1
+--- !u!82 &1417822605
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417822599}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &1465271867
 GameObject:
   m_ObjectHideFlags: 0
@@ -1725,6 +2117,7 @@ GameObject:
   - component: {fileID: 1465271870}
   - component: {fileID: 1465271869}
   - component: {fileID: 1465271872}
+  - component: {fileID: 1465271873}
   m_Layer: 5
   m_Name: Button_MachineB
   m_TagString: Untagged
@@ -1860,6 +2253,103 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   id: 1
+  SE_button: {fileID: 8300000, guid: 42d1b1a6bd4a94f12a1e2f20d1a78a39, type: 3}
+--- !u!82 &1465271873
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1465271867}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1001 &1601997607
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Result Scene.unity
+++ b/Assets/Scenes/Result Scene.unity
@@ -484,6 +484,7 @@ GameObject:
   - component: {fileID: 874561091}
   - component: {fileID: 874561090}
   - component: {fileID: 874561089}
+  - component: {fileID: 874561093}
   m_Layer: 5
   m_Name: Restart Button
   m_TagString: Untagged
@@ -523,6 +524,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 42380999dbfd7d4bcbbaf20c3fadf4d8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  SE_select: {fileID: 8300000, guid: 9908835e1668942cebe8f5fe51df81ed, type: 3}
 --- !u!114 &874561090
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -617,6 +619,102 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 874561087}
   m_CullTransparentMesh: 1
+--- !u!82 &874561093
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 874561087}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &930915337
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Title Scene.unity
+++ b/Assets/Scenes/Title Scene.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.24647538, g: 0.28234535, b: 0.3457032, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028305, g: 0.22571313, b: 0.3069213, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -518,6 +518,7 @@ GameObject:
   - component: {fileID: 895856242}
   - component: {fileID: 895856241}
   - component: {fileID: 895856244}
+  - component: {fileID: 895856245}
   m_Layer: 5
   m_Name: Button
   m_TagString: Untagged
@@ -651,6 +652,103 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 42380999dbfd7d4bcbbaf20c3fadf4d8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  SE_select: {fileID: 8300000, guid: 9908835e1668942cebe8f5fe51df81ed, type: 3}
+--- !u!82 &895856245
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 895856239}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 0}
+  m_PlayOnAwake: 0
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &1664086970
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/MachineSelectScene/BackToTitle.cs
+++ b/Assets/Scripts/MachineSelectScene/BackToTitle.cs
@@ -5,8 +5,15 @@ using UnityEngine;
 
 public class BackToTitle : MonoBehaviour
 {
+    public AudioClip SE_cancel;
     public void OnClick()
     {
+        StartCoroutine("transTitleScene", SE_cancel);
+    }
+    IEnumerator transTitleScene(AudioClip audio)
+    {
+        GetComponent<AudioSource>().PlayOneShot(audio);
+        yield return new WaitForSeconds(audio.length);
         StartCoroutine(SceneTransitioner.Transition("Title Scene", ""));
     }
 }

--- a/Assets/Scripts/MachineSelectScene/MachineSelect.cs
+++ b/Assets/Scripts/MachineSelectScene/MachineSelect.cs
@@ -7,10 +7,11 @@ using UnityEngine.UI;
 public class MachineSelect : MonoBehaviour
 {
     public int id;
+    public AudioClip SE_button;
 
     public void OnClick()
     {
-
+        GetComponent<AudioSource>().PlayOneShot(SE_button);
         var machine = GameObject.Find("MachineSelectManager");
         machine.GetComponent<MachineSelectManager>().id = id;
         var str = "Selected machine ID is " + machine.GetComponent<MachineSelectManager>().id;

--- a/Assets/Scripts/MachineSelectScene/SG.cs
+++ b/Assets/Scripts/MachineSelectScene/SG.cs
@@ -9,6 +9,7 @@ class MachineSelectData {
 }
 public class SG : MonoBehaviour
 {
+    public AudioClip SE_select;
     void Start()
     {
         Button btn = GetComponent<Button>();
@@ -18,9 +19,14 @@ public class SG : MonoBehaviour
     {
         var machine = GameObject.Find("MachineSelectManager");
         var id = machine.GetComponent<MachineSelectManager>().id;
-        var str = "Slelected machine ID is " + id.ToString();
-        Debug.Log(str);
+        Debug.Log("Selected machine ID is " + id.ToString());
         MachineSelectData data = new MachineSelectData(){ id = id };
+        StartCoroutine(transCityTrialScene(SE_select, data));
+    }
+    IEnumerator transCityTrialScene(AudioClip audio, MachineSelectData data)
+    {
+        GetComponent<AudioSource>().PlayOneShot(audio);
+        yield return new WaitForSeconds(audio.length);
         StartCoroutine(SceneTransitioner.Transition("CityTrial", data));
     }
 }

--- a/Assets/Scripts/StartGame.cs
+++ b/Assets/Scripts/StartGame.cs
@@ -5,8 +5,16 @@ using UnityEngine;
 
 public class StartGame : MonoBehaviour
 {
+    public AudioClip SE_select;
     public void OnClick()
     {
+        StartCoroutine("transMachineSelectScene", SE_select);
+    }
+
+    IEnumerator transMachineSelectScene(AudioClip audio)
+    {
+        GetComponent<AudioSource>().PlayOneShot(audio);
+        yield return new WaitForSeconds(audio.length);
         StartCoroutine(SceneTransitioner.Transition("MachineSelectScene", ""));
     }
 }


### PR DESCRIPTION
# 内容
- システム系のSEを実装した
- 「Assets/Audio/」にmp3ファイルを入れた
# 詳細
- 利用したシステム音は以下の三種類
    - （Select）Assets/Audio/System/button70.mp3：決定ボタンの音
    - （Cancel）Assets/Audio/System/system19.mp3：キャンセルボタンの音
    - （Button）Assets/Audio/System/button30.mp3：ボタン選択の音

- Title Scene
    - （Select）Start Gameボタン
- Machine Select Scene
    - （Select）Start Gameボタン
    - （Cancel）BackToTitleボタン
    - （Button）各マシンを選択時
- Result Scene
    - （Select）Restart Gameボタン

- シーンを遷移するボタンは、コルーチンを使ってSEが鳴り終わってから遷移するようにした