### PR TITLE
フィールドアイテムの調整

### DIFF
--- a/Assets/Scripts/ItemScripts/FieldItemController.cs
+++ b/Assets/Scripts/ItemScripts/FieldItemController.cs
@@ -16,11 +16,7 @@ public class FieldItemController : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        survivalTimeCount -= Time.deltaTime;
-        if (survivalTimeCount <= 0)
-        {
-            Destroy(this.gameObject);
-        }
+        
     }
 
     private void FixedUpdate()

--- a/Assets/Scripts/ItemScripts/ItemManager.cs
+++ b/Assets/Scripts/ItemScripts/ItemManager.cs
@@ -8,9 +8,9 @@ public class ItemManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-        int bombItemNum = 30;
-        int cannonItemNum = 30;
-        int recoverItemNum = 5;
+        int bombItemNum = 7;
+        int cannonItemNum = 7;
+        int recoverItemNum = 3;
 
         float range = 80; // アイテムの出現する範囲
         float center = 310*0.5f; // CenterPoleの座標 * Filed1のスケール

--- a/Assets/Scripts/ItemScripts/ItemManager.cs
+++ b/Assets/Scripts/ItemScripts/ItemManager.cs
@@ -12,19 +12,22 @@ public class ItemManager : MonoBehaviour
         int cannonItemNum = 30;
         int recoverItemNum = 5;
 
+        float range = 80; // アイテムの出現する範囲
+        float center = 310*0.5f; // CenterPoleの座標 * Filed1のスケール
+
         for (int i = 0; i < bombItemNum; i++) {
             Addressables.InstantiateAsync("Assets/Prefabs/BombItem.prefab", 
-                new Vector3(Random.value * 250, 0.5f, Random.value * 250), 
+                new Vector3(Random.Range(center-range, center+range), 0.5f, Random.Range(center-range, center+range)), 
                 this.transform.rotation);
         }
         for (int i = 0; i < cannonItemNum; i++) {
             Addressables.InstantiateAsync("Assets/Prefabs/CannonItem.prefab", 
-                new Vector3(Random.value * 250, 0.5f, Random.value * 250), 
+                new Vector3(Random.Range(center-range, center+range), 0.5f, Random.Range(center-range, center+range)), 
                 this.transform.rotation);
         }
         for (int i = 0; i < recoverItemNum; i++) {
             Addressables.InstantiateAsync("Assets/Prefabs/RecoverItem.prefab", 
-                new Vector3(Random.value * 250, 0.5f, Random.value * 250), 
+                new Vector3(Random.Range(center-range, center+range), 0.5f, Random.Range(center-range, center+range)), 
                 this.transform.rotation);
         }           
     }

--- a/Assets/Scripts/ItemScripts/ItemManager.cs
+++ b/Assets/Scripts/ItemScripts/ItemManager.cs
@@ -10,7 +10,7 @@ public class ItemManager : MonoBehaviour
     {
         int bombItemNum = 30;
         int cannonItemNum = 30;
-        int recoverItemNum = 30;
+        int recoverItemNum = 5;
 
         for (int i = 0; i < bombItemNum; i++) {
             Addressables.InstantiateAsync("Assets/Prefabs/BombItem.prefab", 


### PR DESCRIPTION
# 概要
- アイテムの出現数
  - ボム：7個
  - キャノン：7個
  - 回復：3個
- アイテムの出現範囲
  - マップの中心に160×160の範囲にアイテムランダムに出現
- アイテムが時間で消える処理を削除⇒アイテムがずっと残り続けるようになった