### PR TITLE
ウィンドウのピクセルサイズを環境によって変えるように変更

### DIFF
--- a/Assets/Scripts/Entrypoint.cs
+++ b/Assets/Scripts/Entrypoint.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+
+public class Entrypoint
+{
+    private const float windowScaleRatio = 2f / 3;
+    private const float windowSizeRatio = 9f / 16;
+    
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void EntryPoint()
+    {
+#if !UNITY_EDITOR
+        var width = Screen.currentResolution.width;
+        var height = Screen.currentResolution.height;
+        if (width / (float) height < 16f / 9f)
+        {
+            var w = width * windowScaleRatio;
+            var h = w * windowSizeRatio;
+            Screen.SetResolution((int)w, (int)h, false);
+        }
+        else
+        {
+            var h = width * windowScaleRatio;
+            var w = h / windowSizeRatio;
+            Screen.SetResolution((int)w, (int)h, false);
+        }
+#endif
+    }
+}

--- a/Assets/Scripts/Entrypoint.cs.meta
+++ b/Assets/Scripts/Entrypoint.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 87d194d2c9951d0488bf32acdd5c15bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -42,8 +42,8 @@ PlayerSettings:
   m_SplashScreenLogos: []
   m_VirtualRealitySplashScreen: {fileID: 0}
   m_HolographicTrackingLossScreen: {fileID: 0}
-  defaultScreenWidth: 1024
-  defaultScreenHeight: 768
+  defaultScreenWidth: 1920
+  defaultScreenHeight: 1080
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
   m_StereoRenderingPath: 0


### PR DESCRIPTION
# 内容

- ウィンドウのサイズ比率を16(縦):9(横)に変更
- ディスプレイサイズによってウィンドウサイズを変更
  - 16:9の比率より高さの比率が大きいとき、画面の横幅の2/3をウィンドウの横幅として、16:9になるように縦幅を決定
  - 16:9の比率より横の比率が大きいとき、画面の縦幅の2/3をウィンドウの縦幅として、16:9になるように横幅を決定
  
    → どのような画面比率でも、16:9のウィンドウが画面に収まるようにウィンドウサイズを設定