### PR TITLE
炎の当たり判定修正

### DIFF
--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -116,10 +116,6 @@ MonoBehaviour:
     m_Address: Assets/JMO Assets/WarFX/_Effects/MuzzleFlashes/4Planes/WFX_MF 4P RIFLE2.prefab
     m_ReadOnly: 0
     m_SerializedLabels: []
-  - m_GUID: 0a3972e964dcd2b47b2a3bc58d35d554
-    m_Address: Assets/FXIFIED/Stylized VFX Free Pack/Prefabs/FX_Healing_AOE_AA.prefab
-    m_ReadOnly: 0
-    m_SerializedLabels: []
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: 76fdcae5f47a56c038b13938d9296310, type: 2}
   m_SchemaSet:

--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -116,6 +116,10 @@ MonoBehaviour:
     m_Address: Assets/JMO Assets/WarFX/_Effects/MuzzleFlashes/4Planes/WFX_MF 4P RIFLE2.prefab
     m_ReadOnly: 0
     m_SerializedLabels: []
+  - m_GUID: 0a3972e964dcd2b47b2a3bc58d35d554
+    m_Address: Assets/FXIFIED/Stylized VFX Free Pack/Prefabs/FX_Healing_AOE_AA.prefab
+    m_ReadOnly: 0
+    m_SerializedLabels: []
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: 76fdcae5f47a56c038b13938d9296310, type: 2}
   m_SchemaSet:

--- a/Assets/Scenes/CityTrial.unity
+++ b/Assets/Scenes/CityTrial.unity
@@ -1403,19 +1403,19 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 0.67559016
       objectReference: {fileID: 0}
     - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7071068
+      value: 0.7372774
       objectReference: {fileID: 0}
     - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -1423,7 +1423,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 90
+      value: 95
       objectReference: {fileID: 0}
     - target: {fileID: 4584431484625042, guid: 007c57e2df8e9b144b99f471b84f3d56, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -3365,6 +3365,26 @@ PrefabInstance:
       propertyPath: m_Name
       value: RotatingWall
       objectReference: {fileID: 0}
+    - target: {fileID: 1388745263167192900, guid: 47dcc90c35ca3a64bb67d28dd977038c,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 0.8581267
+      objectReference: {fileID: 0}
+    - target: {fileID: 1388745263167192900, guid: 47dcc90c35ca3a64bb67d28dd977038c,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 0.6356581
+      objectReference: {fileID: 0}
+    - target: {fileID: 1388745263167192900, guid: 47dcc90c35ca3a64bb67d28dd977038c,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.060861085
+      objectReference: {fileID: 0}
+    - target: {fileID: 1388745263167192900, guid: 47dcc90c35ca3a64bb67d28dd977038c,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 0.07421645
+      objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}
       propertyPath: m_RootOrder
@@ -3388,7 +3408,7 @@ PrefabInstance:
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 6.27
+      value: 6.22
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}
@@ -3398,7 +3418,7 @@ PrefabInstance:
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -0.02
+      value: -0.15
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}
@@ -3408,17 +3428,17 @@ PrefabInstance:
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1388745263167192901, guid: 47dcc90c35ca3a64bb67d28dd977038c,
         type: 3}


### PR DESCRIPTION
# 概要
- 当たり判定の幅を小さくした
- 当たり判定の長さも短くした
- パーティクルが当たり判定に対して遅れていたので，パーティクルを10°進めた

### 修正前
![炎の当たり判定_修正前](https://user-images.githubusercontent.com/82761537/159229450-14ff87fa-1366-4de9-95d5-ff14df4d41af.jpg)


### 修正後
![炎の当たり判定_修正後](https://user-images.githubusercontent.com/82761537/159229456-a293544f-ae21-4c6a-83fc-92b1fe1661e5.jpg)

### 今後の作業
- 当たり判定が小さくなった分被ダメが減ったので，調整する必要あるか？
